### PR TITLE
Make "serve" serve all files in the slides folder

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -204,8 +204,19 @@ pub async fn start(config: Config) -> Result<(), Error> {
                 ws.on_upgrade(upgrade)
             })
     };
+
+    let assets = {
+        let assets_path: PathBuf = config
+            .input
+            .parent()
+            .unwrap_or_else(|| Path::new("/"))
+            .to_path_buf();
+        warp::fs::dir(assets_path)
+    };
+
     let routes = slides
         .or(ws)
+        .or(assets)
         .with(warp::log("deck"))
         .recover(customize_error);
 


### PR DESCRIPTION
This allows the slides file to refer to other assets in the same
directory (or in any directory below), for example pictures.

If this is deemed insecure (after all, we're giving access to any file in the slides directory or below), we could of course hide this behind a command line option. As far as I could test, this does not allow reading files above the current directory, nor enumerating directories.