### PR TITLE
Add doctype to generated HTML

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -19,6 +19,7 @@ pub struct Output {
 
 impl fmt::Display for Output {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "<!doctype html>")?;
         writeln!(f, "<html>")?;
         writeln!(f, "<head>")?;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -100,6 +100,7 @@ async fn get_slides(
 }
 
 const ERROR_MESSAGE: &str = r#"
+<!doctype html>
 <html>
 <body>
     <h1>Deck encountered an expected error</h1>


### PR DESCRIPTION
When a HTML doctype is missing, some browsers render a document in quirks mode [(MDN reference)](https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode#how_does_mozilla_determine_which_mode_to_use.3f). One quirks mode effect is `<table>`s not inheriting `font-size` CSS rules (this can be seen in the Table slide in the example `slides.md` presentation in Firefox and Chrome)

This pull request adds `<!doctype html>` in the two places in Deck where I found HTML being generated.